### PR TITLE
Added Latitude and Longitude Fields

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,8 @@ Returns the URL to an static map image of the address. Currently, Google Maps' A
         {street_2}
         {city}, {region} {postal_code}
         {country}
+		{lat}
+		{lng}
     {/address_field}
 
 If you need more control over the output, use the tag pair to output each part of the address individually.

--- a/vz_address/ft.vz_address.php
+++ b/vz_address/ft.vz_address.php
@@ -26,7 +26,9 @@ class Vz_address_ft extends EE_Fieldtype {
         'city' => '',
         'region' => '',
         'postal_code' => '',
-        'country' => 'US'
+        'country' => 'US',
+		'lat' => '',
+		'lng' => ''
     );
   
 	/**
@@ -63,12 +65,11 @@ class Vz_address_ft extends EE_Fieldtype {
                 .vz_address input { width:97%; padding:4px; }
                 .vz_address select { width:101%; }
                 .vz_address_name_field input { width:98.5%; }
-                .vz_address_street_field, .vz_address_city_field { float:left; width:49%; padding-right:1%; }
+                .vz_address_street_field, .vz_address_city_field, .vz_address_country_field { float:left; width:49%; padding-right:1%; }
                 .vz_address_street_2_field { float:right; width:49%; padding-left:1%; }
-                .vz_address_region_field { float:left; width:24%; padding-left:1%; }
-                .vz_address_postal_code_field { float:right; width:24%; }
-                .vz_address_region_field input, .vz_address_postal_code_field input { width:94%; }
-                .vz_address_country_field { width:48%; }
+                .vz_address_region_field, .vz_address_lat_field { float:left; width:24%; padding-left:1%; }
+                .vz_address_postal_code_field, .vz_address_lng_field { float:right; width:24%; }
+                .vz_address_region_field input, .vz_address_postal_code_field input, .vz_address_lat_field input, .vz_address_lng_field input { width:94%; }
                 .matrix .vz_address input { width:98.5%; }
                 .matrix .vz_address select { width:100%; }
                 .vz_address_region_cell { float:left; width:48%; }
@@ -282,6 +283,35 @@ class Vz_address_ft extends EE_Fieldtype {
         }
         else
         {
+			//If the lat and lng fields weren't manually filled out
+			if($data['lat'] == '' && $data['lng'] == '')
+			{
+				$this->EE->load->library('curl');
+				
+				$address = urlencode($data['street'] . ' '
+									. $data['street_2'] . ' '
+									. $data['city'] . ' '
+									. $data['region'] . ' '
+									. $data['postal_code'] . ' '
+									. $data['country']
+									);
+				
+				$request = $this->EE->curl->simple_get('http://maps.googleapis.com/maps/api/geocode/json?sensor=false&address=' . $address);
+				
+				$request = json_decode($request);
+
+				if(!empty($request->results))
+				{		
+					$geometry = $request->results[0]->geometry->location;
+
+					if($geometry)
+					{
+						$data['lat'] = $geometry->lat;
+						$data['lng'] = $geometry->lng;
+					}
+				}
+			}
+			
         	return json_encode($data);
         }
     }

--- a/vz_address/language/english/lang.vz_address.php
+++ b/vz_address/language/english/lang.vz_address.php
@@ -9,6 +9,8 @@ $lang = array(
     'region' => 'State/Province',
     'postal_code' => 'Postal Code',
     'country' => 'Country',
+	'lat' => 'Latitude',
+	'lng' => 'Longitude',
     
     'display_name' => 'Display the "Name" field?',
     'display_previous' => 'Allow user to select from previously entered addresses?',

--- a/vz_address/libraries/Curl.php
+++ b/vz_address/libraries/Curl.php
@@ -1,0 +1,375 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * CodeIgniter Curl Class
+ *
+ * Work with remote servers via cURL much easier than using the native PHP bindings.
+ *
+ * @package        	CodeIgniter
+ * @subpackage    	Libraries
+ * @category    	Libraries
+ * @author        	Philip Sturgeon
+ * @license         http://philsturgeon.co.uk/code/dbad-license
+ * @link			http://philsturgeon.co.uk/code/codeigniter-curl
+ */
+class Curl {
+
+	protected $_ci;                 // CodeIgniter instance
+	protected $response = '';       // Contains the cURL response for debug
+	protected $session;             // Contains the cURL handler for a session
+	protected $url;                 // URL of the session
+	protected $options = array();   // Populates curl_setopt_array
+	protected $headers = array();   // Populates extra HTTP headers
+	public $error_code;             // Error code returned as an int
+	public $error_string;           // Error message returned as a string
+	public $info;                   // Returned after request (elapsed time, etc)
+
+	function __construct($url = '')
+	{
+		$this->_ci = & get_instance();
+		log_message('debug', 'cURL Class Initialized');
+
+		if ( ! $this->is_enabled())
+		{
+			log_message('error', 'cURL Class - PHP was not built with cURL enabled. Rebuild PHP with --with-curl to use cURL.');
+		}
+
+		$url AND $this->create($url);
+	}
+
+	public function __call($method, $arguments)
+	{
+		if (in_array($method, array('simple_get', 'simple_post', 'simple_put', 'simple_delete')))
+		{
+			// Take off the "simple_" and past get/post/put/delete to _simple_call
+			$verb = str_replace('simple_', '', $method);
+			array_unshift($arguments, $verb);
+			return call_user_func_array(array($this, '_simple_call'), $arguments);
+		}
+	}
+
+	/* =================================================================================
+	 * SIMPLE METHODS
+	 * Using these methods you can make a quick and easy cURL call with one line.
+	 * ================================================================================= */
+
+	public function _simple_call($method, $url, $params = array(), $options = array())
+	{
+		// Get acts differently, as it doesnt accept parameters in the same way
+		if ($method === 'get')
+		{
+			// If a URL is provided, create new session
+			$this->create($url.($params ? '?'.http_build_query($params, NULL, '&') : ''));
+		}
+
+		else
+		{
+			// If a URL is provided, create new session
+			$this->create($url);
+
+			$this->{$method}($params);
+		}
+
+		// Add in the specific options provided
+		$this->options($options);
+
+		return $this->execute();
+	}
+
+	public function simple_ftp_get($url, $file_path, $username = '', $password = '')
+	{
+		// If there is no ftp:// or any protocol entered, add ftp://
+		if ( ! preg_match('!^(ftp|sftp)://! i', $url))
+		{
+			$url = 'ftp://' . $url;
+		}
+
+		// Use an FTP login
+		if ($username != '')
+		{
+			$auth_string = $username;
+
+			if ($password != '')
+			{
+				$auth_string .= ':' . $password;
+			}
+
+			// Add the user auth string after the protocol
+			$url = str_replace('://', '://' . $auth_string . '@', $url);
+		}
+
+		// Add the filepath
+		$url .= $file_path;
+
+		$this->option(CURLOPT_BINARYTRANSFER, TRUE);
+		$this->option(CURLOPT_VERBOSE, TRUE);
+
+		return $this->execute();
+	}
+
+	/* =================================================================================
+	 * ADVANCED METHODS
+	 * Use these methods to build up more complex queries
+	 * ================================================================================= */
+
+	public function post($params = array(), $options = array())
+	{
+		// If its an array (instead of a query string) then format it correctly
+		if (is_array($params))
+		{
+			$params = http_build_query($params, NULL, '&');
+		}
+
+		// Add in the specific options provided
+		$this->options($options);
+
+		$this->http_method('post');
+
+		$this->option(CURLOPT_POST, TRUE);
+		$this->option(CURLOPT_POSTFIELDS, $params);
+	}
+
+	public function put($params = array(), $options = array())
+	{
+		// If its an array (instead of a query string) then format it correctly
+		if (is_array($params))
+		{
+			$params = http_build_query($params, NULL, '&');
+		}
+
+		// Add in the specific options provided
+		$this->options($options);
+
+		$this->http_method('put');
+		$this->option(CURLOPT_POSTFIELDS, $params);
+
+		// Override method, I think this overrides $_POST with PUT data but... we'll see eh?
+		$this->option(CURLOPT_HTTPHEADER, array('X-HTTP-Method-Override: PUT'));
+	}
+
+	public function delete($params, $options = array())
+	{
+		// If its an array (instead of a query string) then format it correctly
+		if (is_array($params))
+		{
+			$params = http_build_query($params, NULL, '&');
+		}
+
+		// Add in the specific options provided
+		$this->options($options);
+
+		$this->http_method('delete');
+
+		$this->option(CURLOPT_POSTFIELDS, $params);
+	}
+
+	public function set_cookies($params = array())
+	{
+		if (is_array($params))
+		{
+			$params = http_build_query($params, NULL, '&');
+		}
+
+		$this->option(CURLOPT_COOKIE, $params);
+		return $this;
+	}
+
+	public function http_header($header, $content = NULL)
+	{
+		$this->headers[] = $content ? $header . ': ' . $content : $header;
+	}
+
+	public function http_method($method)
+	{
+		$this->options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+		return $this;
+	}
+
+	public function http_login($username = '', $password = '', $type = 'any')
+	{
+		$this->option(CURLOPT_HTTPAUTH, constant('CURLAUTH_' . strtoupper($type)));
+		$this->option(CURLOPT_USERPWD, $username . ':' . $password);
+		return $this;
+	}
+
+	public function proxy($url = '', $port = 80)
+	{
+		$this->option(CURLOPT_HTTPPROXYTUNNEL, TRUE);
+		$this->option(CURLOPT_PROXY, $url . ':' . $port);
+		return $this;
+	}
+
+	public function proxy_login($username = '', $password = '')
+	{
+		$this->option(CURLOPT_PROXYUSERPWD, $username . ':' . $password);
+		return $this;
+	}
+
+	public function ssl($verify_peer = TRUE, $verify_host = 2, $path_to_cert = NULL)
+	{
+		if ($verify_peer)
+		{
+			$this->option(CURLOPT_SSL_VERIFYPEER, TRUE);
+			$this->option(CURLOPT_SSL_VERIFYHOST, $verify_host);
+			$this->option(CURLOPT_CAINFO, $path_to_cert);
+		}
+		else
+		{
+			$this->option(CURLOPT_SSL_VERIFYPEER, FALSE);
+		}
+		return $this;
+	}
+
+	public function options($options = array())
+	{
+		// Merge options in with the rest - done as array_merge() does not overwrite numeric keys
+		foreach ($options as $option_code => $option_value)
+		{
+			$this->option($option_code, $option_value);
+		}
+
+		// Set all options provided
+		curl_setopt_array($this->session, $this->options);
+
+		return $this;
+	}
+
+	public function option($code, $value)
+	{
+		if (is_string($code) && !is_numeric($code))
+		{
+			$code = constant('CURLOPT_' . strtoupper($code));
+		}
+
+		$this->options[$code] = $value;
+		return $this;
+	}
+
+	// Start a session from a URL
+	public function create($url)
+	{
+		// If no a protocol in URL, assume its a CI link
+		if ( ! preg_match('!^\w+://! i', $url))
+		{
+			$this->_ci->load->helper('url');
+			$url = site_url($url);
+		}
+
+		$this->url = $url;
+		$this->session = curl_init($this->url);
+
+		return $this;
+	}
+
+	// End a session and return the results
+	public function execute()
+	{
+		// Set two default options, and merge any extra ones in
+		if ( ! isset($this->options[CURLOPT_TIMEOUT]))
+		{
+			$this->options[CURLOPT_TIMEOUT] = 30;
+		}
+		if ( ! isset($this->options[CURLOPT_RETURNTRANSFER]))
+		{
+			$this->options[CURLOPT_RETURNTRANSFER] = TRUE;
+		}
+		if ( ! isset($this->options[CURLOPT_FAILONERROR]))
+		{
+			$this->options[CURLOPT_FAILONERROR] = TRUE;
+		}
+
+		// Only set follow location if not running securely
+		if ( ! ini_get('safe_mode') && ! ini_get('open_basedir'))
+		{
+			// Ok, follow location is not set already so lets set it to true
+			if ( ! isset($this->options[CURLOPT_FOLLOWLOCATION]))
+			{
+				$this->options[CURLOPT_FOLLOWLOCATION] = TRUE;
+			}
+		}
+
+		if ( ! empty($this->headers))
+		{
+			$this->option(CURLOPT_HTTPHEADER, $this->headers);
+		}
+
+		$this->options();
+
+		// Execute the request & and hide all output
+		$this->response = curl_exec($this->session);
+		$this->info = curl_getinfo($this->session);
+		
+		// Request failed
+		if ($this->response === FALSE)
+		{
+			$errno = curl_errno($this->session);
+			$error = curl_error($this->session);
+			
+			curl_close($this->session);
+			$this->set_defaults();
+			
+			$this->error_code = $errno;
+			$this->error_string = $error;
+			
+			return FALSE;
+		}
+
+		// Request successful
+		else
+		{
+			curl_close($this->session);
+			$this->last_response = $this->response;
+			$this->set_defaults();
+			return $this->last_response;
+		}
+	}
+
+	public function is_enabled()
+	{
+		return function_exists('curl_init');
+	}
+
+	public function debug()
+	{
+		echo "=============================================<br/>\n";
+		echo "<h2>CURL Test</h2>\n";
+		echo "=============================================<br/>\n";
+		echo "<h3>Response</h3>\n";
+		echo "<code>" . nl2br(htmlentities($this->last_response)) . "</code><br/>\n\n";
+
+		if ($this->error_string)
+		{
+			echo "=============================================<br/>\n";
+			echo "<h3>Errors</h3>";
+			echo "<strong>Code:</strong> " . $this->error_code . "<br/>\n";
+			echo "<strong>Message:</strong> " . $this->error_string . "<br/>\n";
+		}
+
+		echo "=============================================<br/>\n";
+		echo "<h3>Info</h3>";
+		echo "<pre>";
+		print_r($this->info);
+		echo "</pre>";
+	}
+
+	public function debug_request()
+	{
+		return array(
+			'url' => $this->url
+		);
+	}
+
+	public function set_defaults()
+	{
+		$this->response = '';
+		$this->headers = array();
+		$this->options = array();
+		$this->error_code = NULL;
+		$this->error_string = '';
+		$this->session = NULL;
+	}
+
+}
+
+/* End of file Curl.php */
+/* Location: ./application/libraries/Curl.php */


### PR DESCRIPTION
We were already using this awesome addon on a site, and we needed to have the latitude and longitude associated with each entry. My first route was to create a separate extension, but then you had to tie the address field to the separate latitude and longitude fields. So I figured why not just add those fields into the fieldtype.

If the latitude and longitude fields are left empty, it takes the address that was filled in and hits the Google API to fill in the latitude and longitude fields.
