### PR TITLE
Fix issue with single quotes

### DIFF
--- a/ee2/vz_address/ft.vz_address.php
+++ b/ee2/vz_address/ft.vz_address.php
@@ -397,7 +397,7 @@ class Vz_address_ft extends EE_Fieldtype {
      */
     public function pre_process($data)
     {
-        $data = htmlspecialchars_decode($data);
+        $data = html_entity_decode($data, ENT_QUOTES);
         $decoded = json_decode($data);
         $decoded = $decoded ? $decoded : @unserialize($data);
         return array_merge($this->fields, (array) $decoded);


### PR DESCRIPTION
Previously single quotes would remain encoded in the text input in the edit entry form. This fixes the issue.