### PR TITLE
Fix PHP error when rendering country name

### DIFF
--- a/ee2/vz_address/ft.vz_address.php
+++ b/ee2/vz_address/ft.vz_address.php
@@ -535,7 +535,7 @@ class Vz_address_ft extends EE_Fieldtype {
         }
         else
         {
-            return $address['country_name'];
+            return ee()->lang->line('vz_address_'.$address['country']);
         }
     }
 


### PR DESCRIPTION
This fixes the following PHP error:

```
A PHP Error was encountered
Severity: Notice
Message: Undefined index: country_name
Filename: vz_address/ft.vz_address.php
Line Number: 538
```
